### PR TITLE
Build a simple entity

### DIFF
--- a/src/client/java/com/meepercreeper/MeepercreeperClient.java
+++ b/src/client/java/com/meepercreeper/MeepercreeperClient.java
@@ -1,10 +1,22 @@
 package com.meepercreeper;
 
+import com.meepercreeper.entity.ModEntities;
+import com.meepercreeper.entity.client.MeeperModel;
+import com.meepercreeper.entity.client.MeeperRenderer;
+import com.meepercreeper.entity.client.ModEntityModelLayers;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 
 public class MeepercreeperClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		// This entrypoint is suitable for setting up client-specific logic, such as rendering.
+		
+		// Register entity renderers
+		EntityRendererRegistry.register(ModEntities.MEEPER, MeeperRenderer::new);
+		
+		// Register entity model layers
+		EntityModelLayerRegistry.registerModelLayer(ModEntityModelLayers.MEEPER, MeeperModel::getTexturedModelData);
 	}
 }

--- a/src/client/java/com/meepercreeper/entity/client/MeeperModel.java
+++ b/src/client/java/com/meepercreeper/entity/client/MeeperModel.java
@@ -1,0 +1,88 @@
+package com.meepercreeper.entity.client;
+
+import com.meepercreeper.entity.MeeperEntity;
+import net.minecraft.client.model.*;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.MathHelper;
+
+public class MeeperModel<T extends MeeperEntity> extends EntityModel<T> {
+    private final ModelPart body;
+    private final ModelPart head;
+    private final ModelPart leg1;
+    private final ModelPart leg2;
+    private final ModelPart leg3;
+    private final ModelPart leg4;
+
+    public MeeperModel(ModelPart root) {
+        this.body = root.getChild("body");
+        this.head = root.getChild("head");
+        this.leg1 = root.getChild("leg1");
+        this.leg2 = root.getChild("leg2");
+        this.leg3 = root.getChild("leg3");
+        this.leg4 = root.getChild("leg4");
+    }
+
+    public static TexturedModelData getTexturedModelData() {
+        ModelData modelData = new ModelData();
+        ModelPartData modelPartData = modelData.getRoot();
+
+        // Body
+        modelPartData.addChild("body", ModelPartBuilder.create()
+                .uv(18, 4)
+                .cuboid(-6.0F, -10.0F, -7.0F, 12.0F, 18.0F, 10.0F),
+                ModelTransform.pivot(0.0F, 5.0F, 2.0F));
+
+        // Head
+        modelPartData.addChild("head", ModelPartBuilder.create()
+                .uv(0, 0)
+                .cuboid(-4.0F, -4.0F, -6.0F, 8.0F, 8.0F, 6.0F),
+                ModelTransform.pivot(0.0F, -4.0F, -8.0F));
+
+        // Legs
+        modelPartData.addChild("leg1", ModelPartBuilder.create()
+                .uv(0, 16)
+                .cuboid(-2.0F, 0.0F, -2.0F, 4.0F, 12.0F, 4.0F),
+                ModelTransform.pivot(-3.0F, 12.0F, 7.0F));
+
+        modelPartData.addChild("leg2", ModelPartBuilder.create()
+                .uv(0, 16)
+                .cuboid(-2.0F, 0.0F, -2.0F, 4.0F, 12.0F, 4.0F),
+                ModelTransform.pivot(3.0F, 12.0F, 7.0F));
+
+        modelPartData.addChild("leg3", ModelPartBuilder.create()
+                .uv(0, 16)
+                .cuboid(-2.0F, 0.0F, -2.0F, 4.0F, 12.0F, 4.0F),
+                ModelTransform.pivot(-3.0F, 12.0F, -5.0F));
+
+        modelPartData.addChild("leg4", ModelPartBuilder.create()
+                .uv(0, 16)
+                .cuboid(-2.0F, 0.0F, -2.0F, 4.0F, 12.0F, 4.0F),
+                ModelTransform.pivot(3.0F, 12.0F, -5.0F));
+
+        return TexturedModelData.of(modelData, 64, 32);
+    }
+
+    @Override
+    public void setAngles(T entity, float limbAngle, float limbDistance, float animationProgress, float headYaw, float headPitch) {
+        this.head.pitch = headPitch * 0.017453292F;
+        this.head.yaw = headYaw * 0.017453292F;
+
+        // Walking animation
+        this.leg1.pitch = MathHelper.cos(limbAngle * 0.6662F) * 1.4F * limbDistance;
+        this.leg2.pitch = MathHelper.cos(limbAngle * 0.6662F + (float)Math.PI) * 1.4F * limbDistance;
+        this.leg3.pitch = MathHelper.cos(limbAngle * 0.6662F + (float)Math.PI) * 1.4F * limbDistance;
+        this.leg4.pitch = MathHelper.cos(limbAngle * 0.6662F) * 1.4F * limbDistance;
+    }
+
+    @Override
+    public void render(MatrixStack matrices, VertexConsumer vertices, int light, int overlay, int color) {
+        body.render(matrices, vertices, light, overlay, color);
+        head.render(matrices, vertices, light, overlay, color);
+        leg1.render(matrices, vertices, light, overlay, color);
+        leg2.render(matrices, vertices, light, overlay, color);
+        leg3.render(matrices, vertices, light, overlay, color);
+        leg4.render(matrices, vertices, light, overlay, color);
+    }
+}

--- a/src/client/java/com/meepercreeper/entity/client/MeeperRenderer.java
+++ b/src/client/java/com/meepercreeper/entity/client/MeeperRenderer.java
@@ -1,0 +1,20 @@
+package com.meepercreeper.entity.client;
+
+import com.meepercreeper.Meepercreeper;
+import com.meepercreeper.entity.MeeperEntity;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.util.Identifier;
+
+public class MeeperRenderer extends MobEntityRenderer<MeeperEntity, MeeperModel<MeeperEntity>> {
+    private static final Identifier TEXTURE = Identifier.of(Meepercreeper.MOD_ID, "textures/entity/meeper.png");
+
+    public MeeperRenderer(EntityRendererFactory.Context context) {
+        super(context, new MeeperModel<>(context.getPart(ModEntityModelLayers.MEEPER)), 0.6f);
+    }
+
+    @Override
+    public Identifier getTexture(MeeperEntity entity) {
+        return TEXTURE;
+    }
+}

--- a/src/client/java/com/meepercreeper/entity/client/ModEntityModelLayers.java
+++ b/src/client/java/com/meepercreeper/entity/client/ModEntityModelLayers.java
@@ -1,0 +1,10 @@
+package com.meepercreeper.entity.client;
+
+import com.meepercreeper.Meepercreeper;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.util.Identifier;
+
+public class ModEntityModelLayers {
+    public static final EntityModelLayer MEEPER = new EntityModelLayer(
+            Identifier.of(Meepercreeper.MOD_ID, "meeper"), "main");
+}

--- a/src/main/java/com/meepercreeper/Meepercreeper.java
+++ b/src/main/java/com/meepercreeper/Meepercreeper.java
@@ -1,5 +1,7 @@
 package com.meepercreeper;
 
+import com.meepercreeper.entity.ModEntities;
+import com.meepercreeper.item.ModItems;
 import net.fabricmc.api.ModInitializer;
 
 import org.slf4j.Logger;
@@ -20,5 +22,11 @@ public class Meepercreeper implements ModInitializer {
 		// Proceed with mild caution.
 
 		LOGGER.info("Hello Fabric world!");
+		
+		// Register entities
+		ModEntities.registerEntities();
+		
+		// Register items
+		ModItems.registerModItems();
 	}
 }

--- a/src/main/java/com/meepercreeper/entity/MeeperEntity.java
+++ b/src/main/java/com/meepercreeper/entity/MeeperEntity.java
@@ -1,0 +1,67 @@
+package com.meepercreeper.entity;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ai.goal.*;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.PassiveEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+
+public class MeeperEntity extends AnimalEntity {
+
+    public MeeperEntity(EntityType<? extends AnimalEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Override
+    protected void initGoals() {
+        // Basic AI goals for the entity
+        this.goalSelector.add(0, new SwimGoal(this));
+        this.goalSelector.add(1, new EscapeDangerGoal(this, 2.0));
+        this.goalSelector.add(2, new AnimalMateGoal(this, 1.0));
+        this.goalSelector.add(3, new TemptGoal(this, 1.25, stack -> stack.isOf(net.minecraft.item.Items.WHEAT), false));
+        this.goalSelector.add(4, new FollowParentGoal(this, 1.1));
+        this.goalSelector.add(5, new WanderAroundFarGoal(this, 1.0));
+        this.goalSelector.add(6, new LookAtEntityGoal(this, PlayerEntity.class, 6.0f));
+        this.goalSelector.add(7, new LookAroundGoal(this));
+    }
+
+    public static DefaultAttributeContainer.Builder createMeeperAttributes() {
+        return AnimalEntity.createMobAttributes()
+                .add(EntityAttributes.MAX_HEALTH, 20.0)
+                .add(EntityAttributes.MOVEMENT_SPEED, 0.25)
+                .add(EntityAttributes.FOLLOW_RANGE, 16.0);
+    }
+
+    @Override
+    protected SoundEvent getAmbientSound() {
+        return SoundEvents.ENTITY_COW_AMBIENT;
+    }
+
+    @Override
+    protected SoundEvent getHurtSound(net.minecraft.entity.damage.DamageSource damageSource) {
+        return SoundEvents.ENTITY_COW_HURT;
+    }
+
+    @Override
+    protected SoundEvent getDeathSound() {
+        return SoundEvents.ENTITY_COW_DEATH;
+    }
+
+    @Override
+    public boolean isBreedingItem(net.minecraft.item.ItemStack stack) {
+        return stack.isOf(net.minecraft.item.Items.WHEAT);
+    }
+
+    @Override
+    public @Nullable PassiveEntity createChild(ServerWorld world, PassiveEntity entity) {
+        return ModEntities.MEEPER.create(world);
+    }
+}

--- a/src/main/java/com/meepercreeper/entity/ModEntities.java
+++ b/src/main/java/com/meepercreeper/entity/ModEntities.java
@@ -1,0 +1,29 @@
+package com.meepercreeper.entity;
+
+import com.meepercreeper.Meepercreeper;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
+import net.minecraft.entity.EntityDimensions;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnGroup;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+public class ModEntities {
+    
+    public static final EntityType<MeeperEntity> MEEPER = Registry.register(
+            Registries.ENTITY_TYPE,
+            Identifier.of(Meepercreeper.MOD_ID, "meeper"),
+            FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, MeeperEntity::new)
+                    .dimensions(EntityDimensions.fixed(0.9f, 1.4f))
+                    .build()
+    );
+
+    public static void registerEntities() {
+        Meepercreeper.LOGGER.info("Registering entities for " + Meepercreeper.MOD_ID);
+        
+        // Register entity attributes
+        FabricDefaultAttributeRegistry.register(MEEPER, MeeperEntity.createMeeperAttributes());
+    }
+}

--- a/src/main/java/com/meepercreeper/item/ModItems.java
+++ b/src/main/java/com/meepercreeper/item/ModItems.java
@@ -1,0 +1,30 @@
+package com.meepercreeper.item;
+
+import com.meepercreeper.Meepercreeper;
+import com.meepercreeper.entity.ModEntities;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+public class ModItems {
+    
+    public static final Item MEEPER_SPAWN_EGG = registerItem("meeper_spawn_egg",
+            new SpawnEggItem(ModEntities.MEEPER, 0x7e9680, 0xc5d1c5, new Item.Settings()));
+
+    private static Item registerItem(String name, Item item) {
+        return Registry.register(Registries.ITEM, Identifier.of(Meepercreeper.MOD_ID, name), item);
+    }
+
+    public static void registerModItems() {
+        Meepercreeper.LOGGER.info("Registering items for " + Meepercreeper.MOD_ID);
+        
+        // Add items to creative menu
+        ItemGroupEvents.modifyEntriesEvent(ItemGroups.SPAWN_EGGS).register(entries -> {
+            entries.add(MEEPER_SPAWN_EGG);
+        });
+    }
+}

--- a/src/main/resources/assets/meepercreeper/lang/en_us.json
+++ b/src/main/resources/assets/meepercreeper/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "entity.meepercreeper.meeper": "Meeper",
+  "item.meepercreeper.meeper_spawn_egg": "Meeper Spawn Egg"
+}

--- a/src/main/resources/assets/meepercreeper/models/item/meeper_spawn_egg.json
+++ b/src/main/resources/assets/meepercreeper/models/item/meeper_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+  "parent": "item/template_spawn_egg"
+}

--- a/src/main/resources/assets/meepercreeper/textures/entity/meeper_texture_info.txt
+++ b/src/main/resources/assets/meepercreeper/textures/entity/meeper_texture_info.txt
@@ -1,0 +1,21 @@
+MEEPER ENTITY TEXTURE REQUIREMENTS:
+
+File name: meeper.png
+Dimensions: 64x32 pixels
+Format: PNG with transparency
+
+The texture should be laid out as follows:
+- Head: 8x8x6 cuboid starting at UV (0,0)
+- Body: 12x18x10 cuboid starting at UV (18,4)  
+- Legs: 4x12x4 cuboids starting at UV (0,16)
+
+Colors suggested:
+- Primary: Green/teal (#7e9680)
+- Secondary: Light green (#c5d1c5)
+
+You'll need to create this texture file using an image editor like:
+- Blockbench (recommended for Minecraft entity textures)
+- GIMP, Photoshop, or similar image editor
+- Paint.NET with appropriate plugins
+
+Place the finished texture as: meeper.png in this directory.


### PR DESCRIPTION
Adds a new 'Meeper' entity to the Minecraft Fabric mod as requested, including its definition, registration, client-side rendering, and spawn egg.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c21d634-0a3e-4eec-8660-57b296612ab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c21d634-0a3e-4eec-8660-57b296612ab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

